### PR TITLE
HRV Frequency-Domain Integration & Respiration Belt UI

### DIFF
--- a/breath_state/lib/screens/record_screen.dart
+++ b/breath_state/lib/screens/record_screen.dart
@@ -1,14 +1,20 @@
+import 'dart:async';
 import 'dart:developer' as developer;
+import 'package:breath_state/providers/go_direct_provider.dart';
 import 'package:breath_state/providers/nav_bar_provider.dart';
 import 'package:breath_state/providers/polar_connect_provider.dart';
+import 'package:breath_state/services/breath_rate/belt_breath_rate.dart';
 import 'package:breath_state/services/breath_rate/record.dart';
 import 'package:breath_state/services/heart_rate/polar_connect.dart';
+import 'package:breath_state/services/hrv_analysis/hrv_frequency_domain.dart';
 import 'package:breath_state/services/hrv_analysis/hrv_time_domain.dart';
 import 'package:breath_state/services/resonance_service/res_freq.dart';
 import 'package:breath_state/services/resonance_service/rf_trainer.dart';
 import 'package:breath_state/theme/app_theme.dart';
 import 'package:breath_state/widgets/glass_card.dart';
+import 'package:breath_state/widgets/hrv_frequency_result_card.dart';
 import 'package:breath_state/widgets/hrv_result_card.dart';
+import 'package:breath_state/widgets/respiration_waveform_card.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -28,6 +34,12 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
   bool isRecordingHR = false;
   bool isRecordingBR = false;
   int breathingRate = -2;
+
+  bool _beltActiveForSession = false;
+  String _breathSource = 'Microphone';
+  final List<double> _beltForceValues = [];
+  StreamSubscription<double>? _beltSub;
+  DateTime? _beltStartTime;
 
   @override
   void initState() {
@@ -51,6 +63,28 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
     required bool recordHR,
   }) async {
     WakelockPlus.enable();
+
+    final gdProvider = context.read<GoDirectProvider>();
+    if (gdProvider.isConnected) {
+      try {
+        await gdProvider.startMeasurements(sensorNumbers: [1], periodMs: 100);
+        _beltActiveForSession = true;
+        _breathSource = 'Respiration Belt';
+        _beltForceValues.clear();
+        _beltStartTime = DateTime.now();
+        _beltSub = gdProvider.respirationForceStream.listen((v) {
+          _beltForceValues.add(v);
+        });
+      } catch (e) {
+        developer.log('Belt start failed, falling back to mic: $e');
+        _beltActiveForSession = false;
+        _breathSource = 'Microphone';
+      }
+    } else {
+      _beltActiveForSession = false;
+      _breathSource = 'Microphone';
+    }
+
     if (recordBR) {
       _recorder = SoundRecorder();
       setState(() {
@@ -61,9 +95,39 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
       _recorder!.startRecord().then((rate) {
         if (mounted) {
           setState(() {
-            breathingRate = rate;
+            if (_beltActiveForSession && _beltForceValues.length >= 30) {
+              final result = estimateBreathRateFromForce(
+                _beltForceValues,
+                sampleRateHz: 10.0,
+              );
+              breathingRate = result.bpm.round();
+            } else {
+              breathingRate = rate;
+              _breathSource = 'Microphone';
+            }
             isRecordingBR = false;
           });
+          _stopBelt();
+          _checkStopEffect();
+        }
+      });
+    } else if (_beltActiveForSession) {
+      setState(() {
+        breathingRate = -1;
+        isRecordingBR = true;
+      });
+      _pulseController.repeat(reverse: true);
+      Future.delayed(const Duration(seconds: 30), () {
+        if (mounted && _beltActiveForSession) {
+          final result = estimateBreathRateFromForce(
+            _beltForceValues,
+            sampleRateHz: 10.0,
+          );
+          setState(() {
+            breathingRate = result.bpm.round();
+            isRecordingBR = false;
+          });
+          _stopBelt();
           _checkStopEffect();
         }
       });
@@ -94,11 +158,23 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
     }
   }
 
+  Future<void> _stopBelt() async {
+    _beltSub?.cancel();
+    _beltSub = null;
+    final gdProvider = context.read<GoDirectProvider>();
+    if (gdProvider.isStreaming) {
+      await gdProvider.stopMeasurements();
+    }
+    _beltActiveForSession = false;
+  }
+
   Future<void> _stopHRRecording() async {
     final polarConnectProvider = context.read<PolarConnectProvider>();
     PolarConnect? polar = polarConnectProvider.getPolarConnect();
     if (polar != null) {
       try {
+        final rrIntervals = List<double>.from(polar.sessionRrIntervals);
+
         await polar.stopRecording();
         final hrvResult = polar.lastSessionHrv;
         setState(() {
@@ -109,7 +185,14 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
         _checkStopEffect();
 
         if (hrvResult != null && mounted) {
-          _showHrvResultSheet(hrvResult);
+          HrvFrequencyDomainResult? freqResult;
+          try {
+            freqResult = HrvFrequencyDomainAnalyzer.analyze(rrIntervals);
+          } catch (e) {
+            debugPrint('Frequency-domain HRV skipped: $e');
+          }
+
+          _showHrvResultSheet(hrvResult, freqResult);
         }
       } catch (e) {
         developer.log("Error stopping HR recording: $e");
@@ -121,7 +204,10 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
     _checkStopEffect();
   }
 
-  void _showHrvResultSheet(HrvTimeDomainResult result) {
+  void _showHrvResultSheet(
+    HrvTimeDomainResult result, [
+    HrvFrequencyDomainResult? freqResult,
+  ]) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     showModalBottomSheet(
       context: context,
@@ -158,6 +244,10 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
                 ),
                 const SizedBox(height: 16),
                 HrvResultCard(result: result),
+                if (freqResult != null) ...[
+                  const SizedBox(height: 16),
+                  HrvFrequencyResultCard(result: freqResult),
+                ],
               ],
             ),
           ),
@@ -201,83 +291,85 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
     );
   }
 
-  void _showRecordDialog() {
-    bool recordBR = false;
-    bool recordHR = false;
+  void _handleStartRecording() {
+    final gdProvider = context.read<GoDirectProvider>();
+    final isBeltConnected = gdProvider.isConnected;
 
+    if (isBeltConnected) {
+      _startRecording(recordBR: true, recordHR: true);
+    } else {
+      _showMicFallbackCaution();
+    }
+  }
+
+  void _showMicFallbackCaution() {
     showDialog(
       context: context,
-      builder: (context) {
-        return StatefulBuilder(
-          builder: (context, setStateDialog) {
-              return AlertDialog(
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
-              title: Text("Select what to record", style: Theme.of(context).textTheme.titleLarge),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+        icon: Icon(
+          Icons.warning_amber_rounded,
+          color: Colors.amber.shade600,
+          size: 48,
+        ),
+        title: Text(
+          "Respiration Belt Not Connected",
+          style: Theme.of(context).textTheme.titleLarge,
+          textAlign: TextAlign.center,
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              "Breathing rate will be measured using the microphone, which may be less accurate.",
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(height: 1.5),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: AppTheme.softTeal.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: AppTheme.softTeal.withOpacity(0.3),
+                ),
+              ),
+              child: Row(
                 children: [
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).brightness == Brightness.dark 
-                          ? Colors.white.withOpacity(0.05) 
-                          : AppTheme.softTeal.withOpacity(0.08), 
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                        color: Theme.of(context).dividerColor.withOpacity(0.1),
-                      ),
-                    ),
-                    child: CheckboxListTile(
-                      title: Text("Breath Rate", style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold)),
-                      subtitle: Text("Using Microphone", style: Theme.of(context).textTheme.bodySmall),
-                      value: recordBR,
-                      activeColor: AppTheme.softTeal,
-                      checkColor: Colors.white,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                      onChanged: (val) => setStateDialog(() => recordBR = val ?? false),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).brightness == Brightness.dark 
-                          ? Colors.white.withOpacity(0.05) 
-                          : AppTheme.roseAccent.withOpacity(0.08),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                         color: Theme.of(context).dividerColor.withOpacity(0.1),
-                      ),
-                    ),
-                    child: CheckboxListTile(
-                      title: Text("Heart Rate", style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold)),
-                      subtitle: Text("Using Polar Device", style: Theme.of(context).textTheme.bodySmall),
-                      value: recordHR,
-                      activeColor: AppTheme.roseAccent,
-                      checkColor: Colors.white,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                      onChanged: (val) => setStateDialog(() => recordHR = val ?? false),
+                  Icon(Icons.air_rounded, color: AppTheme.softTeal, size: 20),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      "Connect a Vernier Go Direct Respiration Belt for better accuracy.",
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: AppTheme.softTeal,
+                            fontWeight: FontWeight.w600,
+                          ),
                     ),
                   ),
                 ],
               ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: Text("Cancel", style: TextStyle(color: Theme.of(context).textTheme.bodySmall?.color)),
-                ),
-                ElevatedButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                    if (recordBR || recordHR) {
-                      _startRecording(recordBR: recordBR, recordHR: recordHR);
-                    }
-                  },
-                  child: const Text("Start Recording"),
-                ),
-              ],
-            );
-          },
-        );
-      },
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              context.read<NavBarProvider>().changeIndex(3);
+            },
+            child: const Text("Go to Settings"),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context);
+              _startRecording(recordBR: true, recordHR: true);
+            },
+            child: const Text("Continue with Mic"),
+          ),
+        ],
+      ),
     );
   }
 
@@ -322,7 +414,7 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
                         child: GestureDetector(
                           onTap: isActive
                               ? (isRecordingHR ? _stopHRRecording : null)
-                              : _showRecordDialog,
+                              : _handleStartRecording,
                           child: AnimatedBuilder(
                             animation: _pulseController,
                             builder: (context, child) {
@@ -439,7 +531,27 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
                                     ),
                                   const SizedBox(height: 4),
                                   if (isRecordingBR)
-                                     Text("Measuring...", style: TextStyle(color: Theme.of(context).textTheme.bodySmall?.color, fontSize: 10)),
+                                     Text("Measuring...", style: TextStyle(color: Theme.of(context).textTheme.bodySmall?.color, fontSize: 10))
+                                  else if (breathingRate > 0)
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                                      decoration: BoxDecoration(
+                                        color: _breathSource == 'Respiration Belt'
+                                            ? AppTheme.softTeal.withOpacity(0.15)
+                                            : AppTheme.calmBlue.withOpacity(0.15),
+                                        borderRadius: BorderRadius.circular(8),
+                                      ),
+                                      child: Text(
+                                        _breathSource == 'Respiration Belt' ? 'Belt ✓' : 'Mic',
+                                        style: TextStyle(
+                                          color: _breathSource == 'Respiration Belt'
+                                              ? AppTheme.softTeal
+                                              : AppTheme.calmBlue,
+                                          fontSize: 9,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
                                 ],
                               ),
                             ),
@@ -479,7 +591,20 @@ class _RecordScreenState extends State<RecordScreen> with SingleTickerProviderSt
                         ],
                       ),
                       
-                      const SizedBox(height: 24),
+                      const SizedBox(height: 16),
+
+                      Consumer<GoDirectProvider>(
+                        builder: (context, gdProvider, _) {
+                          if (!gdProvider.isStreaming) {
+                            return const SizedBox.shrink();
+                          }
+                          return RespirationWaveformCard(
+                            forceStream: gdProvider.respirationForceStream,
+                          );
+                        },
+                      ),
+
+                      const SizedBox(height: 8),
                       
                       Consumer<PolarConnectProvider>(
                         builder: (context, provider, child) {

--- a/breath_state/lib/services/hrv_analysis/hrv_frequency_domain.dart
+++ b/breath_state/lib/services/hrv_analysis/hrv_frequency_domain.dart
@@ -1,0 +1,281 @@
+library;
+import 'dart:math' as math;
+import 'signal_processing.dart';
+enum PsdMethod { welch, lombScargle }
+
+class FrequencyBand {
+  final String name;
+  final double low; 
+  final double high; 
+  const FrequencyBand(this.name, this.low, this.high);
+}
+
+class BandResult {
+  final String name;
+  final double absolutePower;
+  final double? peakFrequency;
+  final double relativePower;
+  final double logPower;
+  final double? normalizedPower;
+
+  const BandResult({
+    required this.name,
+    required this.absolutePower,
+    this.peakFrequency,
+    required this.relativePower,
+    required this.logPower,
+    this.normalizedPower,
+  });
+}
+
+class HrvFrequencyDomainResult {
+  final BandResult ulf;
+  final BandResult vlf;
+  final BandResult lf;
+  final BandResult hf;
+  final BandResult vhf;
+
+  final double totalPower; 
+  final double lfHfRatio;
+
+  final List<double> frequencies;
+  final List<double> psd;
+
+  final PsdMethod method;
+  final int interpolationRate;
+
+  final String? durationWarning;
+
+  const HrvFrequencyDomainResult({
+    required this.ulf,
+    required this.vlf,
+    required this.lf,
+    required this.hf,
+    required this.vhf,
+    required this.totalPower,
+    required this.lfHfRatio,
+    required this.frequencies,
+    required this.psd,
+    required this.method,
+    this.interpolationRate = 4,
+    this.durationWarning,
+  });
+
+  Map<String, String> essentials() {
+    return {
+      'LF Power': '${lf.absolutePower.toStringAsFixed(1)} ms²',
+      'HF Power': '${hf.absolutePower.toStringAsFixed(1)} ms²',
+      'LF/HF': lfHfRatio.isFinite
+          ? lfHfRatio.toStringAsFixed(2)
+          : 'N/A',
+      'Total Power': '${totalPower.toStringAsFixed(1)} ms²',
+    };
+  }
+
+  Map<String, List<({String label, double? value, String unit})>>
+      allBandMetrics() {
+    final Map<String, List<({String label, double? value, String unit})>>
+        groups = {};
+
+    for (final b in [ulf, vlf, lf, hf, vhf]) {
+      groups[b.name] = [
+        (label: '${b.name} Power', value: b.absolutePower, unit: 'ms²'),
+        (label: '${b.name} Peak', value: b.peakFrequency, unit: 'Hz'),
+        (
+          label: '${b.name} Relative',
+          value: b.relativePower * 100,
+          unit: '%'
+        ),
+        (label: '${b.name} Log', value: b.logPower, unit: 'ln(ms²)'),
+        if (b.normalizedPower != null)
+          (
+            label: '${b.name} Norm',
+            value: b.normalizedPower! * 100,
+            unit: 'n.u.'
+          ),
+      ];
+    }
+    return groups;
+  }
+
+  Map<String, double?> toNeuroKitMap() {
+    final m = <String, double?>{};
+    for (final b in [ulf, vlf, lf, hf, vhf]) {
+      m['HRV_${b.name}'] = b.absolutePower;
+      m['HRV_${b.name}Peak'] = b.peakFrequency;
+      m['HRV_${b.name}Relative'] = b.relativePower;
+      m['HRV_${b.name}Log'] =
+          b.logPower.isFinite ? b.logPower : null;
+      if (b.normalizedPower != null) {
+        m['HRV_${b.name}n'] = b.normalizedPower;
+      }
+    }
+    m['HRV_TP'] = totalPower;
+    m['HRV_LFHF'] = lfHfRatio.isFinite ? lfHfRatio : null;
+    return m;
+  }
+}
+
+class HrvFrequencyDomainAnalyzer {
+  static const FrequencyBand _ulf = FrequencyBand('ULF', 0.0, 0.0033);
+  static const FrequencyBand _vlf = FrequencyBand('VLF', 0.0033, 0.04);
+  static const FrequencyBand _lf = FrequencyBand('LF', 0.04, 0.15);
+  static const FrequencyBand _hf = FrequencyBand('HF', 0.15, 0.4);
+  static const FrequencyBand _vhf = FrequencyBand('VHF', 0.4, 0.5);
+
+  static HrvFrequencyDomainResult analyze(
+    List<double> rrIntervalsMs, {
+    PsdMethod method = PsdMethod.welch,
+    int interpolationRate = 4,
+    int nFreqs = 500,
+    bool normalize = true,
+    double minFrequency = 0.0,
+    double maxFrequency = 0.5,
+    int? nperseg,
+  }) {
+    if (rrIntervalsMs.length < 3) {
+      throw ArgumentError(
+          'Need ≥ 3 RR intervals for frequency analysis '
+          '(got ${rrIntervalsMs.length})');
+    }
+
+    final int nRR = rrIntervalsMs.length;
+    final times = List<double>.filled(nRR, 0.0);
+    times[0] = rrIntervalsMs[0] / 1000.0;
+    for (int i = 1; i < nRR; i++) {
+      times[i] = times[i - 1] + rrIntervalsMs[i] / 1000.0;
+    }
+
+    final double durationSec = times.last - times.first;
+
+    String? durationWarning;
+    if (durationSec < 60) {
+      durationWarning =
+          'Recording < 1 min (${durationSec.toStringAsFixed(0)}s). '
+          'Frequency-domain results may be unreliable.';
+    } else if (durationSec < 120) {
+      durationWarning =
+          'Recording < 2 min. VLF and LF power estimates '
+          'have limited reliability.';
+    }
+
+    List<double> freq;
+    List<double> psd;
+
+    switch (method) {
+      case PsdMethod.welch:
+        final (_, interpRRI) = cubicInterpolate(
+          times,
+          rrIntervalsMs,
+          interpolationRate.toDouble(),
+        );
+
+        final double mean =
+            interpRRI.reduce((a, b) => a + b) / interpRRI.length;
+        final detrended = interpRRI.map((v) => v - mean).toList();
+
+        final effectiveNperseg =
+            nperseg ?? detrended.length;
+
+        (freq, psd) = welchPSD(
+          detrended,
+          interpolationRate.toDouble(),
+          nperseg: effectiveNperseg.clamp(4, detrended.length),
+        );
+
+      case PsdMethod.lombScargle:
+        final double fMin =
+            minFrequency <= 0 ? 0.003 : minFrequency;
+        freq = List<double>.generate(
+          nFreqs,
+          (i) => fMin + i * (maxFrequency - fMin) / (nFreqs - 1),
+        );
+        psd = lombScarglePSD(times, rrIntervalsMs, freq);
+    }
+
+    final double totalPower =
+        freq.length >= 2 ? trapz(freq, psd) : 0.0;
+
+    BandResult _band(FrequencyBand band) {
+      final idx = <int>[];
+      for (int i = 0; i < freq.length; i++) {
+        if (freq[i] >= band.low && freq[i] < band.high) idx.add(i);
+      }
+      if (idx.isEmpty) {
+        return BandResult(
+          name: band.name,
+          absolutePower: 0.0,
+          peakFrequency: null,
+          relativePower: 0.0,
+          logPower: double.negativeInfinity,
+        );
+      }
+
+      final bF = idx.map((i) => freq[i]).toList();
+      final bP = idx.map((i) => psd[i]).toList();
+
+      final double absPow =
+          bF.length >= 2 ? trapz(bF, bP) : bP[0] * (band.high - band.low);
+
+      int peakI = 0;
+      for (int i = 1; i < bP.length; i++) {
+        if (bP[i] > bP[peakI]) peakI = i;
+      }
+
+      return BandResult(
+        name: band.name,
+        absolutePower: absPow,
+        peakFrequency: bF[peakI],
+        relativePower: totalPower > 0 ? absPow / totalPower : 0.0,
+        logPower: absPow > 0 ? math.log(absPow) : double.negativeInfinity,
+      );
+    }
+
+    final ulfR = _band(_ulf);
+    final vlfR = _band(_vlf);
+    BandResult lfR = _band(_lf);
+    BandResult hfR = _band(_hf);
+    final vhfR = _band(_vhf);
+
+    if (normalize) {
+      final double lfHfSum = lfR.absolutePower + hfR.absolutePower;
+      if (lfHfSum > 0) {
+        lfR = BandResult(
+          name: lfR.name,
+          absolutePower: lfR.absolutePower,
+          peakFrequency: lfR.peakFrequency,
+          relativePower: lfR.relativePower,
+          logPower: lfR.logPower,
+          normalizedPower: lfR.absolutePower / lfHfSum,
+        );
+        hfR = BandResult(
+          name: hfR.name,
+          absolutePower: hfR.absolutePower,
+          peakFrequency: hfR.peakFrequency,
+          relativePower: hfR.relativePower,
+          logPower: hfR.logPower,
+          normalizedPower: hfR.absolutePower / lfHfSum,
+        );
+      }
+    }
+
+    final double lfHf = hfR.absolutePower > 0
+        ? lfR.absolutePower / hfR.absolutePower
+        : double.infinity;
+
+    return HrvFrequencyDomainResult(
+      ulf: ulfR,
+      vlf: vlfR,
+      lf: lfR,
+      hf: hfR,
+      vhf: vhfR,
+      totalPower: totalPower,
+      lfHfRatio: lfHf,
+      frequencies: freq,
+      psd: psd,
+      method: method,
+      interpolationRate: interpolationRate,
+      durationWarning: durationWarning,
+    );
+  }
+}

--- a/breath_state/lib/services/hrv_analysis/signal_processing.dart
+++ b/breath_state/lib/services/hrv_analysis/signal_processing.dart
@@ -1,0 +1,294 @@
+library;
+import 'dart:math' as math;
+
+int nextPowerOfTwo(int n) {
+  if (n <= 1) return 1;
+  int p = 1;
+  while (p < n) {
+    p <<= 1;
+  }
+  return p;
+}
+
+void fftInPlace(List<double> re, List<double> im) {
+  final int n = re.length;
+  assert(n == im.length, 'Real / imag length mismatch');
+  assert(n > 0 && (n & (n - 1)) == 0, 'Length must be a power of 2 (got $n)');
+
+  int j = 0;
+  for (int i = 0; i < n - 1; i++) {
+    if (i < j) {
+      double t = re[i];
+      re[i] = re[j];
+      re[j] = t;
+      t = im[i];
+      im[i] = im[j];
+      im[j] = t;
+    }
+    int m = n >> 1;
+    while (m >= 1 && j >= m) {
+      j -= m;
+      m >>= 1;
+    }
+    j += m;
+  }
+
+  for (int size = 2; size <= n; size <<= 1) {
+    final int half = size >> 1;
+    final double theta = -2.0 * math.pi / size;
+    final double wR = math.cos(theta);
+    final double wI = math.sin(theta);
+
+    for (int i = 0; i < n; i += size) {
+      double uR = 1.0, uI = 0.0;
+      for (int k = 0; k < half; k++) {
+        final int a = i + k;
+        final int b = a + half;
+        final double tR = uR * re[b] - uI * im[b];
+        final double tI = uR * im[b] + uI * re[b];
+        re[b] = re[a] - tR;
+        im[b] = im[a] - tI;
+        re[a] += tR;
+        im[a] += tI;
+        final double nu = uR * wR - uI * wI;
+        uI = uR * wI + uI * wR;
+        uR = nu;
+      }
+    }
+  }
+}
+
+List<double> hannWindow(int n) {
+  if (n <= 1) return List.filled(n, 1.0);
+  return List<double>.generate(
+    n,
+    (i) => 0.5 * (1.0 - math.cos(2.0 * math.pi * i / (n - 1))),
+  );
+}
+
+class CubicSpline {
+  final List<double> _x;
+  final List<double> _a; 
+  late final List<double> _b, _c, _d;
+
+  CubicSpline(this._x, List<double> y)
+      : _a = List<double>.from(y) {
+    assert(_x.length == _a.length && _x.length >= 2,
+        'Need ≥ 2 knots for a spline');
+    _build();
+  }
+
+  void _build() {
+    final int n = _x.length - 1; 
+    _b = List<double>.filled(n, 0.0);
+    _c = List<double>.filled(n + 1, 0.0);
+    _d = List<double>.filled(n, 0.0);
+
+    if (n == 1) {
+      _b[0] = (_a[1] - _a[0]) / (_x[1] - _x[0]);
+      return;
+    }
+
+    final h = List<double>.generate(n, (i) => _x[i + 1] - _x[i]);
+    final alpha = List<double>.filled(n, 0.0);
+    for (int i = 1; i < n; i++) {
+      alpha[i] = 3.0 / h[i] * (_a[i + 1] - _a[i]) -
+          3.0 / h[i - 1] * (_a[i] - _a[i - 1]);
+    }
+
+    final l = List<double>.filled(n + 1, 1.0);
+    final mu = List<double>.filled(n + 1, 0.0);
+    final z = List<double>.filled(n + 1, 0.0);
+
+    for (int i = 1; i < n; i++) {
+      l[i] = 2.0 * (_x[i + 1] - _x[i - 1]) - h[i - 1] * mu[i - 1];
+      mu[i] = h[i] / l[i];
+      z[i] = (alpha[i] - h[i - 1] * z[i - 1]) / l[i];
+    }
+
+    for (int j = n - 1; j >= 0; j--) {
+      _c[j] = z[j] - mu[j] * _c[j + 1];
+      _b[j] = (_a[j + 1] - _a[j]) / h[j] -
+          h[j] * (_c[j + 1] + 2.0 * _c[j]) / 3.0;
+      _d[j] = (_c[j + 1] - _c[j]) / (3.0 * h[j]);
+    }
+  }
+
+  double evaluate(double x) {
+    final int i = _interval(x);
+    final double dx = x - _x[i];
+    return _a[i] + _b[i] * dx + _c[i] * dx * dx + _d[i] * dx * dx * dx;
+  }
+
+  List<double> evaluateList(List<double> xs) => xs.map(evaluate).toList();
+
+  int _interval(double x) {
+    if (x <= _x.first) return 0;
+    if (x >= _x.last) return _x.length - 2;
+    int lo = 0, hi = _x.length - 2;
+    while (lo < hi) {
+      final int mid = (lo + hi) >> 1;
+      if (_x[mid + 1] <= x) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo;
+  }
+}
+
+(List<double>, List<double>) cubicInterpolate(
+  List<double> times,
+  List<double> values,
+  double fs,
+) {
+  assert(times.length == values.length && times.length >= 2);
+  final double dt = 1.0 / fs;
+  final int nOut = ((times.last - times.first) / dt).floor() + 1;
+  final newT = List<double>.generate(nOut, (i) => times.first + i * dt);
+  final spline = CubicSpline(times, values);
+  return (newT, spline.evaluateList(newT));
+}
+
+(List<double>, List<double>) linearInterpolate(
+  List<double> times,
+  List<double> values,
+  double fs,
+) {
+  assert(times.length == values.length && times.length >= 2);
+  final double dt = 1.0 / fs;
+  final int nOut = ((times.last - times.first) / dt).floor() + 1;
+  final newT = List<double>.generate(nOut, (i) => times.first + i * dt);
+  final newV = List<double>.filled(nOut, 0.0);
+
+  int j = 0;
+  for (int i = 0; i < nOut; i++) {
+    final double t = newT[i];
+    while (j < times.length - 2 && times[j + 1] < t) {
+      j++;
+    }
+    if (j >= times.length - 1) {
+      newV[i] = values.last;
+    } else {
+      final double frac = (times[j + 1] != times[j])
+          ? (t - times[j]) / (times[j + 1] - times[j])
+          : 0.0;
+      newV[i] = values[j] + frac * (values[j + 1] - values[j]);
+    }
+  }
+  return (newT, newV);
+}
+
+(List<double>, List<double>) welchPSD(
+  List<double> signal,
+  double fs, {
+  int? nperseg,
+  int? noverlap,
+}) {
+  final int n = signal.length;
+  if (n < 4) return (<double>[0.0], <double>[0.0]);
+
+  nperseg = (nperseg ?? n).clamp(4, n);
+  noverlap ??= nperseg ~/ 2;
+
+  final int step = math.max(1, nperseg - noverlap);
+  final int nfft = nextPowerOfTwo(nperseg);
+  final win = hannWindow(nperseg);
+
+  double s2 = 0.0;
+  for (int i = 0; i < nperseg; i++) {
+    s2 += win[i] * win[i];
+  }
+
+  final int nFreqs = nfft ~/ 2 + 1;
+  final psd = List<double>.filled(nFreqs, 0.0);
+
+  int nSeg = 0;
+  for (int start = 0; start + nperseg <= n; start += step) {
+    nSeg++;
+    final re = List<double>.filled(nfft, 0.0);
+    final im = List<double>.filled(nfft, 0.0);
+    for (int i = 0; i < nperseg; i++) {
+      re[i] = signal[start + i] * win[i];
+    }
+    fftInPlace(re, im);
+    for (int k = 0; k < nFreqs; k++) {
+      double mag2 = re[k] * re[k] + im[k] * im[k];
+      if (k > 0 && k < nfft ~/ 2) mag2 *= 2.0; 
+      psd[k] += mag2;
+    }
+  }
+  if (nSeg == 0) nSeg = 1;
+
+  final double scale = fs * s2 * nSeg;
+  for (int k = 0; k < nFreqs; k++) {
+    psd[k] /= scale;
+  }
+
+  final freqs = List<double>.generate(nFreqs, (k) => k * fs / nfft);
+  return (freqs, psd);
+}
+
+List<double> lombScarglePSD(
+  List<double> times,
+  List<double> values,
+  List<double> frequencies,
+) {
+  final int n = times.length;
+  final int nf = frequencies.length;
+  if (n < 2) return List<double>.filled(nf, 0.0);
+
+  final double mean = values.reduce((a, b) => a + b) / n;
+  final c = values.map((v) => v - mean).toList();
+  final double variance = c.fold<double>(0.0, (s, v) => s + v * v) / n;
+  if (variance < 1e-30) return List<double>.filled(nf, 0.0);
+
+  final psd = List<double>.filled(nf, 0.0);
+
+  for (int fi = 0; fi < nf; fi++) {
+    final double f = frequencies[fi];
+    if (f <= 0) continue;
+    final double w = 2.0 * math.pi * f;
+
+    double s2 = 0.0, c2 = 0.0;
+    for (int i = 0; i < n; i++) {
+      s2 += math.sin(2.0 * w * times[i]);
+      c2 += math.cos(2.0 * w * times[i]);
+    }
+    final double tau = math.atan2(s2, c2) / (2.0 * w);
+
+    double ccNum = 0, ssNum = 0, ccDen = 0, ssDen = 0;
+    for (int i = 0; i < n; i++) {
+      final double ph = w * (times[i] - tau);
+      final double cp = math.cos(ph), sp = math.sin(ph);
+      ccNum += c[i] * cp;
+      ssNum += c[i] * sp;
+      ccDen += cp * cp;
+      ssDen += sp * sp;
+    }
+    psd[fi] = 0.5 *
+        ((ccNum * ccNum) / ccDen.clamp(1e-30, double.infinity) +
+            (ssNum * ssNum) / ssDen.clamp(1e-30, double.infinity));
+  }
+
+  final double df = nf > 1 ? frequencies[1] - frequencies[0] : 1.0;
+  final double psdSum = psd.fold<double>(0.0, (s, v) => s + v);
+  if (psdSum > 0) {
+    final double sf = variance / (psdSum * df);
+    for (int i = 0; i < nf; i++) {
+      psd[i] *= sf;
+    }
+  }
+  return psd;
+}
+
+double trapz(List<double> x, List<double> y) {
+  assert(x.length == y.length);
+  if (x.length < 2) return 0.0;
+  double s = 0.0;
+  for (int i = 0; i < x.length - 1; i++) {
+    s += (x[i + 1] - x[i]) * (y[i] + y[i + 1]);
+  }
+  return s * 0.5;
+}

--- a/breath_state/lib/widgets/hrv_frequency_result_card.dart
+++ b/breath_state/lib/widgets/hrv_frequency_result_card.dart
@@ -1,0 +1,520 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:breath_state/services/hrv_analysis/hrv_frequency_domain.dart';
+import 'package:breath_state/widgets/glass_card.dart';
+import 'package:breath_state/theme/app_theme.dart';
+
+class HrvFrequencyResultCard extends StatefulWidget {
+  final HrvFrequencyDomainResult result;
+  final bool expanded;
+
+  const HrvFrequencyResultCard({
+    super.key,
+    required this.result,
+    this.expanded = false,
+  });
+
+  @override
+  State<HrvFrequencyResultCard> createState() =>
+      _HrvFrequencyResultCardState();
+}
+
+class _HrvFrequencyResultCardState extends State<HrvFrequencyResultCard> {
+  late bool _expanded;
+
+  @override
+  void initState() {
+    super.initState();
+    _expanded = widget.expanded;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return GlassCard(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.stacked_line_chart_rounded,
+                color: AppTheme.roseAccent,
+                size: 24,
+              ),
+              const SizedBox(width: 10),
+              Text(
+                "HRV Frequency Analysis",
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const Spacer(),
+              _buildBadge(context, isDark),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _buildEssentialsGrid(context, isDark),
+          if (_expanded) ...[
+            const SizedBox(height: 20),
+            _buildDivider(isDark),
+            const SizedBox(height: 16),
+            _buildExpandedMetrics(context, isDark),
+            const SizedBox(height: 16),
+            if (widget.result.durationWarning != null)
+              _buildWarningRow(isDark),
+            _buildPsdPlot(isDark),
+            const SizedBox(height: 12),
+            Text(
+              "Column names match NeuroKit2 for cross-validation.",
+              style: TextStyle(
+                fontSize: 10,
+                color: (isDark ? Colors.white : Colors.black).withOpacity(0.4),
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+          const SizedBox(height: 12),
+          Center(
+            child: TextButton.icon(
+              onPressed: () => setState(() => _expanded = !_expanded),
+              icon: Icon(
+                _expanded ? Icons.expand_less : Icons.expand_more,
+                size: 20,
+                color: AppTheme.softTeal,
+              ),
+              label: Text(
+                _expanded ? "Show less" : "Show all metrics",
+                style: TextStyle(
+                  color: AppTheme.softTeal,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 13,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBadge(BuildContext context, bool isDark) {
+    final r = widget.result;
+    final badgeText =
+        r.lfHfRatio.isFinite ? r.lfHfRatio.toStringAsFixed(2) : 'N/A';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: AppTheme.roseAccent.withOpacity(isDark ? 0.2 : 0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        "LF/HF $badgeText",
+        style: TextStyle(
+          color: AppTheme.roseAccent,
+          fontWeight: FontWeight.bold,
+          fontSize: 13,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEssentialsGrid(BuildContext context, bool isDark) {
+    final essentials = widget.result.essentials();
+    final entries = essentials.entries.toList();
+
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: entries.map((e) {
+        return SizedBox(
+          width: (MediaQuery.of(context).size.width - 96) / 2,
+          child: _MetricTile(
+            label: e.key,
+            value: e.value,
+            isDark: isDark,
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildDivider(bool isDark) {
+    return Container(
+      height: 1,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            Colors.transparent,
+            (isDark ? Colors.white : Colors.black).withOpacity(0.15),
+            Colors.transparent,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildExpandedMetrics(BuildContext context, bool isDark) {
+    final groups = widget.result.allBandMetrics();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: groups.entries.map((group) {
+        final validMetrics = group.value.where((m) {
+          return m.value != null && m.value != double.negativeInfinity;
+        }).toList();
+
+        if (validMetrics.isEmpty) return const SizedBox.shrink();
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8, top: 4),
+              child: Text(
+                group.key,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: AppTheme.softTeal.withOpacity(0.8),
+                  letterSpacing: 0.5,
+                ),
+              ),
+            ),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: validMetrics.map((m) {
+                final formatted = _formatMetricValue(m.value!, m.unit);
+                return SizedBox(
+                  width: (MediaQuery.of(context).size.width - 96) / 2,
+                  child: _MetricTile(
+                    label: m.label,
+                    value: formatted,
+                    isDark: isDark,
+                    compact: true,
+                  ),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 8),
+          ],
+        );
+      }).toList(),
+    );
+  }
+
+  String _formatMetricValue(double value, String unit) {
+    switch (unit) {
+      case 'ms²':
+        return '${value.toStringAsFixed(1)} ms²';
+      case 'Hz':
+        return '${value.toStringAsFixed(3)} Hz';
+      case '%':
+        return '${value.toStringAsFixed(1)}%';
+      case 'n.u.':
+        return '${value.toStringAsFixed(1)} n.u.';
+      case 'ln(ms²)':
+        return '${value.toStringAsFixed(3)} ln(ms²)';
+      default:
+        return value.toStringAsFixed(3);
+    }
+  }
+
+  Widget _buildWarningRow(bool isDark) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.warning_amber_rounded,
+            color: Colors.amber,
+            size: 18,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              widget.result.durationWarning!,
+              style: TextStyle(
+                fontSize: 11,
+                color: Colors.amber.shade700,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPsdPlot(bool isDark) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Text(
+            "PSD Spectrum",
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: AppTheme.softTeal.withOpacity(0.8),
+              letterSpacing: 0.5,
+            ),
+          ),
+        ),
+        SizedBox(
+          height: 180,
+          width: double.infinity,
+          child: CustomPaint(
+            painter: _PsdPlotPainter(
+              frequencies: widget.result.frequencies,
+              psd: widget.result.psd,
+              isDark: isDark,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PsdPlotPainter extends CustomPainter {
+  final List<double> frequencies;
+  final List<double> psd;
+  final bool isDark;
+
+  _PsdPlotPainter({
+    required this.frequencies,
+    required this.psd,
+    required this.isDark,
+  });
+
+  static const double _xMin = 0.0;
+  static const double _xMax = 0.5;
+  static const double _lfLow = 0.04;
+  static const double _lfHigh = 0.15;
+  static const double _hfLow = 0.15;
+  static const double _hfHigh = 0.4;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (frequencies.isEmpty || psd.isEmpty) return;
+
+    const double leftMargin = 40;
+    const double bottomMargin = 24;
+    const double topMargin = 8;
+    const double rightMargin = 8;
+
+    final plotWidth = size.width - leftMargin - rightMargin;
+    final plotHeight = size.height - topMargin - bottomMargin;
+
+    double yMax = 0;
+    for (int i = 0; i < frequencies.length; i++) {
+      if (frequencies[i] >= _xMin &&
+          frequencies[i] <= _xMax &&
+          psd[i].isFinite) {
+        yMax = math.max(yMax, psd[i]);
+      }
+    }
+    if (yMax <= 0) yMax = 1;
+    yMax *= 1.1; 
+
+    double xToPixel(double freq) =>
+        leftMargin + (freq - _xMin) / (_xMax - _xMin) * plotWidth;
+    double yToPixel(double power) =>
+        topMargin + plotHeight - (power / yMax) * plotHeight;
+
+    _drawBandFill(canvas, xToPixel, yToPixel, _lfLow, _lfHigh,
+        AppTheme.softTeal.withOpacity(0.2), plotHeight + topMargin);
+    _drawBandFill(canvas, xToPixel, yToPixel, _hfLow, _hfHigh,
+        AppTheme.roseAccent.withOpacity(0.2), plotHeight + topMargin);
+
+    final gridPaint = Paint()
+      ..color = (isDark ? Colors.white : Colors.black).withOpacity(0.15)
+      ..strokeWidth = 0.8;
+
+    for (final boundary in [_lfLow, _lfHigh, _hfHigh]) {
+      final x = xToPixel(boundary);
+      _drawDashedLine(
+          canvas, Offset(x, topMargin), Offset(x, topMargin + plotHeight), gridPaint);
+    }
+
+    final linePaint = Paint()
+      ..color = isDark ? Colors.white : Colors.black87
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    final path = Path();
+    bool started = false;
+    for (int i = 0; i < frequencies.length; i++) {
+      if (frequencies[i] < _xMin || frequencies[i] > _xMax) continue;
+      if (!psd[i].isFinite) continue;
+      final px = xToPixel(frequencies[i]);
+      final py = yToPixel(psd[i]);
+      if (!started) {
+        path.moveTo(px, py);
+        started = true;
+      } else {
+        path.lineTo(px, py);
+      }
+    }
+    canvas.drawPath(path, linePaint);
+
+    final labelStyle = TextStyle(
+      fontSize: 9,
+      color: (isDark ? Colors.white : Colors.black).withOpacity(0.5),
+    );
+
+    _drawText(canvas, "0", Offset(xToPixel(0) - 4, topMargin + plotHeight + 4),
+        labelStyle);
+    _drawText(canvas, "0.15",
+        Offset(xToPixel(0.15) - 10, topMargin + plotHeight + 4), labelStyle);
+    _drawText(canvas, "0.4",
+        Offset(xToPixel(0.4) - 8, topMargin + plotHeight + 4), labelStyle);
+
+    _drawVerticalText(
+      canvas,
+      "PSD (ms²/Hz)",
+      Offset(2, topMargin + plotHeight / 2),
+      TextStyle(
+        fontSize: 8,
+        color: (isDark ? Colors.white : Colors.black).withOpacity(0.4),
+      ),
+    );
+  }
+
+  void _drawBandFill(
+    Canvas canvas,
+    double Function(double) xToPixel,
+    double Function(double) yToPixel,
+    double fLow,
+    double fHigh,
+    Color color,
+    double baseline,
+  ) {
+    final fillPath = Path();
+    fillPath.moveTo(xToPixel(fLow), baseline);
+
+    bool hasPoints = false;
+    for (int i = 0; i < frequencies.length; i++) {
+      if (frequencies[i] >= fLow && frequencies[i] <= fHigh && psd[i].isFinite) {
+        fillPath.lineTo(xToPixel(frequencies[i]), yToPixel(psd[i]));
+        hasPoints = true;
+      }
+    }
+
+    if (!hasPoints) return;
+
+    fillPath.lineTo(xToPixel(fHigh), baseline);
+    fillPath.close();
+
+    canvas.drawPath(fillPath, Paint()..color = color);
+  }
+
+  void _drawDashedLine(
+      Canvas canvas, Offset start, Offset end, Paint paint) {
+    const dashLength = 4.0;
+    const gapLength = 3.0;
+    final dx = end.dx - start.dx;
+    final dy = end.dy - start.dy;
+    final distance = math.sqrt(dx * dx + dy * dy);
+    final ux = dx / distance;
+    final uy = dy / distance;
+
+    double drawn = 0;
+    while (drawn < distance) {
+      final segEnd = math.min(drawn + dashLength, distance);
+      canvas.drawLine(
+        Offset(start.dx + ux * drawn, start.dy + uy * drawn),
+        Offset(start.dx + ux * segEnd, start.dy + uy * segEnd),
+        paint,
+      );
+      drawn += dashLength + gapLength;
+    }
+  }
+
+  void _drawText(Canvas canvas, String text, Offset offset, TextStyle style) {
+    final tp = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    tp.paint(canvas, offset);
+  }
+
+  void _drawVerticalText(
+      Canvas canvas, String text, Offset offset, TextStyle style) {
+    canvas.save();
+    canvas.translate(offset.dx, offset.dy);
+    canvas.rotate(-math.pi / 2);
+    final tp = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    tp.paint(canvas, Offset(-tp.width / 2, 0));
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(covariant _PsdPlotPainter oldDelegate) =>
+      oldDelegate.isDark != isDark;
+}
+
+class _MetricTile extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool isDark;
+  final bool compact;
+
+  const _MetricTile({
+    required this.label,
+    required this.value,
+    required this.isDark,
+    this.compact = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: 12,
+        vertical: compact ? 6 : 10,
+      ),
+      decoration: BoxDecoration(
+        color: (isDark ? Colors.white : Colors.black)
+            .withOpacity(isDark ? 0.06 : 0.04),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: (isDark ? Colors.white : Colors.black).withOpacity(0.06),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: compact ? 10 : 11,
+              fontWeight: FontWeight.w600,
+              color:
+                  (isDark ? Colors.white : Colors.black).withOpacity(0.5),
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: compact ? 13 : 15,
+              fontWeight: FontWeight.bold,
+              color: isDark ? Colors.white : Colors.black87,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Added HrvFrequencyResultCard mirroring HrvResultCard style, showing collapsed essentials (LF, HF, LF/HF, Total Power) and expanded band metrics (ULF/VLF/LF/HF/VHF) with PSD spectrum plot and duration warning.
 
- Integrated frequency-domain computation in _stopHRRecording() with try-catch; displayed via _showHrvResultSheet() below time-domain results.
 
- Edge cases: <3 RR intervals = skipped frequency card, <10 RR = bottom sheet not shown, <2 min = amber duration warning.
 
- Added the Vernier Go Respiration Belt UI in the Record Screen.